### PR TITLE
Allow users to select text

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -43,10 +43,6 @@ a {
 
 blockquote {
   text-align: center;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
 }
 
 .quote {


### PR DESCRIPTION
This is neat because people might want to copy a quote over somewhere, and I personally don't see a reason to disallow it. :smile: 

Works well with #4.
