### PR TITLE
Don't trigger click when selecting text

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -34,6 +34,9 @@ $(document).ready(function() {
   }
 
   $("body, blockquote").on("click", function() {
+    // Prevent switching quote and color if event is triggered by text selection
+    if (getSelection().toString()) return;
+
     randomizeColor();
     randomizeQuote();
   });


### PR DESCRIPTION
In jQuery, a click event is triggered by a mousedown followed by a mouseup,
which a text selection also is, so this uses the Selection API to detect whether
or not the user has selected text, and based on that displays a new quote or
not.

Works well with #3.
