### PR TITLE
Simplify setting "notation" class

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -34,10 +34,7 @@ document.addEventListener('DOMContentLoaded', function() {
       blockquote.classList.remove("flipOutX");
       blockquote.classList.add("flipInX");
       
-      var quoteClass = quote.getAttribute("class")
-      if (quoteClass.indexOf("notation") === -1) {
-        quote.setAttribute("class", quoteClass + " notation")
-      }
+      quote.classList.add("notation");
     }, 1000);
   }
 


### PR DESCRIPTION
This uses [Element.classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) to set the class “notation” if it is not already set on the element on timeout. We can get rid of the conditional, because the classList (a [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList)) is a set, and thus cannot have duplicates.
